### PR TITLE
Remove action keyword

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "Name": "QuickLook",
   "Description": "Use QuickLook to preview files",
   "Author": "Flow Launcher Team",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.QuickLook",
   "ExecuteFileName": "Flow.Launcher.Plugin.QuickLook.dll",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,7 @@
 {
   "ID": "e6a13bf1-5op9-2b96-a7fd-130b7vdt3d14",
-  "ActionKeywords": [ "*" ],
+  "ActionKeywords": [],
+  "HideActionKeywordPanel": true,
   "Name": "QuickLook",
   "Description": "Use QuickLook to preview files",
   "Author": "Flow Launcher Team",


### PR DESCRIPTION
Hide action keyword panel since this plugin does not need action keyword panel.

Remove action keyword so that Flow will not add this plugin into action keyword dictionary.

Version bump for release.