### PR TITLE
Revert action keyword removal

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "ID": "e6a13bf1-5op9-2b96-a7fd-130b7vdt3d14",
-  "ActionKeyword": "",
+  "ActionKeywords": [ "*" ],
   "HideActionKeywordPanel": true,
   "Name": "QuickLook",
   "Description": "Use QuickLook to preview files",


### PR DESCRIPTION
Sorry, I find `"ActionKeyword": ""` and `"ActionKeywords": []` are both not supported in Flow.

So let us set a valid action keyword here